### PR TITLE
shuf: improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,7 @@ name = "uu_shuf"
 version = "0.0.14"
 dependencies = [
  "clap 3.1.18",
+ "memchr 2.5.0",
  "rand",
  "rand_core",
  "uucore",

--- a/src/uu/shuf/Cargo.toml
+++ b/src/uu/shuf/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/shuf.rs"
 
 [dependencies]
 clap = { version = "3.1", features = ["wrap_help", "cargo"] }
+memchr = "2.5.0"
 rand = "0.8"
 rand_core = "0.6"
 uucore = { version=">=0.0.11", package="uucore", path="../../uucore" }

--- a/src/uu/shuf/src/shuf.rs
+++ b/src/uu/shuf/src/shuf.rs
@@ -8,6 +8,7 @@
 // spell-checker:ignore (ToDO) cmdline evec seps rvec fdata
 
 use clap::{crate_version, Arg, Command, Values};
+use memchr::memchr_iter;
 use rand::prelude::SliceRandom;
 use rand::RngCore;
 use std::fs::File;
@@ -218,20 +219,12 @@ fn find_seps(data: &mut Vec<&[u8]>, sep: u8) {
         if data[i].contains(&sep) {
             let this = data.swap_remove(i);
             let mut p = 0;
-            let mut i = 1;
-            loop {
-                if i == this.len() {
-                    break;
-                }
-
-                if this[i] == sep {
-                    data.push(&this[p..i]);
-                    p = i + 1;
-                }
-                i += 1;
+            for i in memchr_iter(sep, this) {
+                data.push(&this[p..i]);
+                p = i + 1;
             }
             if p < this.len() {
-                data.push(&this[p..i]);
+                data.push(&this[p..]);
             }
         }
     }


### PR DESCRIPTION
Use memchr crate to speed up splitting input data by a separator.

Signed-off-by: Christian Menges <christian.menges@outlook.com>